### PR TITLE
Make versuchung python3 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,8 @@ from distutils.core import setup
 from distutils.cmd import Command
 from distutils.spawn import spawn
 
+import sys
+
 try:
     from sphinx.setup_command import BuildDoc
     cmdclass = {'doc': BuildDoc}
@@ -17,7 +19,7 @@ except:
 class TestCommand(Command):
     user_options = []
     def run(self):
-        spawn(["make", "-C", "tests"], verbose = 1)
+        spawn(["make", "-C", "tests", "PYTHON=%s" % (sys.executable,)], verbose = 1)
 
     def initialize_options(self):
         pass

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 from distutils.core import setup
 from distutils.cmd import Command
 from distutils.spawn import spawn
@@ -8,7 +10,7 @@ try:
     from sphinx.setup_command import BuildDoc
     cmdclass = {'doc': BuildDoc}
 except:
-    print "No Sphinx installed (python-sphinx) so no documentation can be build"
+    print("No Sphinx installed (python-sphinx) so no documentation can be build")
     cmdclass = {}
 
 

--- a/src/versuchung/archives.py
+++ b/src/versuchung/archives.py
@@ -12,6 +12,7 @@
 # You should have received a copy of the GNU General Public License along with
 # versuchung.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import print_function
 
 from versuchung.types import Type, InputParameter
 from versuchung.files import Directory, Directory_op_with, File
@@ -183,7 +184,7 @@ class GitArchive(InputParameter, Type, Directory_op_with):
 
             (lines, ret) = shell(cmd)
             if ret != 0 or lines == 0:
-                print "\n".join(lines)
+                print("\n".join(lines))
                 sys.exit(-1)
 
             self.__hash = lines[0].split("\t")[0]
@@ -225,7 +226,7 @@ class GitArchive(InputParameter, Type, Directory_op_with):
             (lines, ret) = shell(cmd, *args)
 
             if ret != 0:
-                print "\n".join(lines)
+                print("\n".join(lines))
                 sys.exit(-1)
 
             if not self.__shallow:
@@ -234,7 +235,7 @@ class GitArchive(InputParameter, Type, Directory_op_with):
                 (lines, ret) = shell(cmd, *args)
 
                 if ret != 0:
-                    print "\n".join(lines)
+                    print("\n".join(lines))
                     sys.exit(-1)
 
 

--- a/src/versuchung/database.py
+++ b/src/versuchung/database.py
@@ -12,6 +12,8 @@
 # You should have received a copy of the GNU General Public License along with
 # versuchung.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 from versuchung.types import Type, InputParameter, OutputParameter
 import logging
 import sqlite3
@@ -91,7 +93,7 @@ class Database_MySQL(InputParameter, OutputParameter, Type, Database_Abstract):
         directory = self.tmp_directory.new_directory(self.name)
         path = os.path.join(directory.path, "my.cnf")
         logging.debug("MYSQL_HOME=%s", path)
-        with os.fdopen(os.open(path, os.O_WRONLY | os.O_CREAT, 0600), 'w') as handle:
+        with os.fdopen(os.open(path, os.O_WRONLY | os.O_CREAT, 0o600), 'w') as handle:
             handle.write("""[client]
 host=%s
 user=%s
@@ -483,7 +485,7 @@ class TableDict(Table, dict):
 class Database_SQlite_Merger:
     def log(self, msg, *args):
         if self.logging:
-            print "merger: " + (msg % args)
+            print("merger: " + (msg % args))
 
     def __init__(self, target_path, source_paths = [], logging = True):
         self.target_path = target_path
@@ -574,8 +576,8 @@ class Database_SQlite_Merger:
 if __name__ == '__main__':
     import sys
     if len(sys.argv) < 2:
-        print sys.argv[0] + " <target-database-file> [<source-db1> <source-db2> ...]"
-        print " -- merges different versuchung sqlite databases into a single one"
+        print(sys.argv[0] + " <target-database-file> [<source-db1> <source-db2> ...]")
+        print(" -- merges different versuchung sqlite databases into a single one")
         sys.exit(-1)
 
     merger = Database_SQlite_Merger(sys.argv[1], sys.argv[2:])

--- a/src/versuchung/execute.py
+++ b/src/versuchung/execute.py
@@ -71,7 +71,7 @@ def __shell(failok, command, *args):
     command = command % args
 
     logging.debug("executing: " + command)
-    p = Popen(command, stdout=PIPE, stderr=STDOUT, shell=True)
+    p = Popen(command, stdout=PIPE, stderr=STDOUT, shell=True, universal_newlines=True)
     stdout = ""
     while True:
         x = p.stdout.readline()

--- a/src/versuchung/execute.py
+++ b/src/versuchung/execute.py
@@ -17,7 +17,10 @@ from versuchung.files import CSV_File
 import logging
 import os
 import resource
-import thread
+try:
+    import thread
+except ImportError:
+    import _thread as thread
 import time
 import pipes
 from versuchung.tools import AdviceManager, Advice

--- a/src/versuchung/experiment.py
+++ b/src/versuchung/experiment.py
@@ -321,10 +321,10 @@ class Experiment(Type, InputParameter):
         for name in self.inputs:
             metadata.update( self.inputs[name].inp_metadata() )
         m = hashlib.md5()
-        m.update("version %s" % str(self.version))
+        m.update(("version %s" % str(self.version)).encode())
         calc_metadata = self.filter_metadata(metadata)
         for key in sorted(calc_metadata.keys()):
-            m.update(key + " " + str(calc_metadata[key]))
+            m.update((key + " " + str(calc_metadata[key])).encode())
 
         self.__experiment_instance = "%s-%s" %(self.title, m.hexdigest())
         self.base_directory = os.path.join(os.curdir, self.__experiment_instance)

--- a/src/versuchung/experiment.py
+++ b/src/versuchung/experiment.py
@@ -169,7 +169,7 @@ class Experiment(Type, InputParameter):
                                  help="list all experiment results")
         self.__parser.add_option('-s', '--symlink', dest='do_symlink', action='store_true',
                                  help="symlink the result dir (as newest)")
-        self.__parser.add_option('-v', '--verbose', dest='verbose', action='count',
+        self.__parser.add_option('-v', '--verbose', dest='verbose', action='count', default=0,
                                  help="increase verbosity (specify multiple times for more)")
 
         for (name, inp) in self.inputs.items():

--- a/src/versuchung/experiment.py
+++ b/src/versuchung/experiment.py
@@ -12,6 +12,7 @@
 # You should have received a copy of the GNU General Public License along with
 # versuchung.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import print_function
 
 from optparse import OptionParser
 import datetime
@@ -149,13 +150,13 @@ class Experiment(Type, InputParameter):
             if type(inp) == LambdaType:
                 continue
             if not isinstance(inp, InputParameter):
-                print "%s cannot be used as an input parameter" % name
+                print("%s cannot be used as an input parameter" % name)
                 sys.exit(-1)
             self.subobjects[name] = inp
 
         for (name, outp) in self.outputs.items():
             if not isinstance(outp, OutputParameter):
-                print "%s cannot be used as an output parameter" % name
+                print("%s cannot be used as an output parameter" % name)
                 sys.exit(-1)
             self.subobjects[name] = outp
 
@@ -219,7 +220,7 @@ class Experiment(Type, InputParameter):
         if self.__opts.do_list:
             for experiment in os.listdir(self.base_directory):
                 if experiment.startswith(self.title):
-                    print "EXP", experiment
+                    print("EXP", experiment)
                     self.__do_list(self.__class__(experiment))
             return None
 
@@ -236,7 +237,7 @@ class Experiment(Type, InputParameter):
         except:
             # Clean up the tmp directory
             if self.suspend_on_error:
-                print "tmp-dir: %s" % self.tmp_directory.path
+                print("tmp-dir: %s" % self.tmp_directory.path)
                 self.suspend_python()
             logging.error("Removing tmp directory")
             shutil.rmtree(self.tmp_directory.path)
@@ -269,8 +270,8 @@ class Experiment(Type, InputParameter):
             content = fd.read()
         d = eval(content)
         content = experiment.__experiment_instance + "\n" + content
-        print "+%s%s" % ("-" * indent,
-                        content.strip().replace("\n", "\n|" + (" " * (indent+1))))
+        print("+%s%s" % ("-" * indent,
+                        content.strip().replace("\n", "\n|" + (" " * (indent+1)))))
         for dirname in d.values():
             if type(dirname) != type(""):
                 continue
@@ -393,7 +394,7 @@ class Experiment(Type, InputParameter):
     def inp_extract_cmdline_parser(self, opts, args):
         self.__experiment_instance = self.inp_parser_extract(opts, None)
         if not self.__experiment_instance:
-            print "Missing argument for %s" % self.title
+            print("Missing argument for %s" % self.title)
             raise ExperimentError
 
         # Resolve symlink relative to the current directory

--- a/src/versuchung/files.py
+++ b/src/versuchung/files.py
@@ -190,7 +190,7 @@ class Executable(File):
         raise NotImplementedError
 
     def inp_metadata(self):
-        return {self.name + "-md5": hashlib.md5(open(self.path).read()).hexdigest()}
+        return {self.name + "-md5": hashlib.md5(open(self.path, "rb").read()).hexdigest()}
 
     def execute(self, cmdline, *args):
         """Does start the executable with meth:`versuchung.execute.shell` and

--- a/src/versuchung/files.py
+++ b/src/versuchung/files.py
@@ -14,7 +14,10 @@
 
 
 from versuchung.types import InputParameter, OutputParameter, Type
-from cStringIO import StringIO
+try:
+        from cStringIO import StringIO
+except ImportError:
+        from io import StringIO
 import shutil
 import csv
 import os, stat

--- a/src/versuchung/search.py
+++ b/src/versuchung/search.py
@@ -12,6 +12,8 @@
 # You should have received a copy of the GNU General Public License along with
 # versuchung.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 import os
 import logging
 
@@ -109,8 +111,8 @@ if __name__ == '__main__':
     import sys
     from versuchung.experiment import Experiment
     if len(sys.argv) != 4:
-        print "%s <experiment-type> <field> <data>" % sys.argv[0]
+        print("%s <experiment-type> <field> <data>" % sys.argv[0])
         sys.exit(-1)
     Experiment.__name__ = sys.argv[1]
     for exp in search_experiment_results(Experiment, ".", {sys.argv[2]: sys.argv[3]}):
-        print exp.path
+        print(exp.path)

--- a/src/versuchung/tex.py
+++ b/src/versuchung/tex.py
@@ -12,6 +12,8 @@
 # You should have received a copy of the GNU General Public License along with
 # versuchung.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 from versuchung.files import File
 import re
 import os
@@ -158,4 +160,4 @@ class DatarefDict(PgfKeyDict):
 
 if __name__ == '__main__':
     import sys
-    print PgfKeyDict(sys.argv[1])
+    print(PgfKeyDict(sys.argv[1]))

--- a/src/versuchung/tools.py
+++ b/src/versuchung/tools.py
@@ -13,6 +13,7 @@
 # versuchung.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import sys
 from functools import wraps
 
 class JavascriptStyleDictAccess(dict):
@@ -131,13 +132,22 @@ class Advice:
         if self.enabled:
             return
         # Hook only in if the methods are overwritten
-        if self.before.im_func != Advice.before.im_func:
-            am.before[self.method].append(self.before)
-        if self.around.im_func != Advice.around.im_func:
-            am.around[self.method].append(self.around)
-        if self.after.im_func != Advice.after.im_func:
-            am.after[self.method].append(self.after)
-        self.enabled = True
+        if sys.version_info[0] == 2:
+            if self.before.im_func != Advice.before.im_func:
+                am.before[self.method].append(self.before)
+            if self.around.im_func != Advice.around.im_func:
+                am.around[self.method].append(self.around)
+            if self.after.im_func != Advice.after.im_func:
+                am.after[self.method].append(self.after)
+            self.enabled = True
+        elif sys.version_info[0] == 3:
+            if self.before.__func__ != Advice.before:
+                am.before[self.method].append(self.before)
+            if self.around.__func__ != Advice.around:
+                am.around[self.method].append(self.around)
+            if self.after.__func__ != Advice.after:
+                am.after[self.method].append(self.after)
+            self.enabled = True
 
     def before(self, args, kwargs):
         return (args, kwargs)

--- a/src/versuchung/tools.py
+++ b/src/versuchung/tools.py
@@ -70,9 +70,9 @@ class AdviceManager(Singleton):
     @staticmethod
     def advicable(func):
         """Decorator to mark a function as advicable"""
-        if not "func_name" in dir(func):
+        if not "__call__" in dir(func):
             raise ValueError("No function adviced")
-        full_name = "%s.%s" % (func.__module__, func.func_name)
+        full_name = "%s.%s" % (func.__module__, func.__name__)
 
         self = AdviceManager()
 

--- a/src/versuchung/types.py
+++ b/src/versuchung/types.py
@@ -12,6 +12,8 @@
 # You should have received a copy of the GNU General Public License along with
 # versuchung.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 import os
 import csv
 from  cStringIO import StringIO
@@ -29,7 +31,7 @@ class SubObjects(dict):
         self.update()
     def update(self):
         if not "parent" in dir(self) and len(self) > 0:
-            print "You probably used python multiprocessing, this might break horrible"
+            print("You probably used python multiprocessing, this might break horrible")
             return
         for name, obj in self.items():
             if self.parent.name != None:

--- a/src/versuchung/types.py
+++ b/src/versuchung/types.py
@@ -16,7 +16,10 @@ from __future__ import print_function
 
 import os
 import csv
-from  cStringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 from optparse import OptionParser
 import copy
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,13 +1,14 @@
 TESTS = $(patsubst ./%,%,$(shell find . -maxdepth 1 -mindepth 1 -type d))
 PHONY = $(TESTS)
 PWD   = $(shell pwd)
+PYTHON := python
 
 check: $(TESTS)
 
 define test_cmd
 $(1): FORCE
 	@echo -n "Running test $(1)..."
-	@cd $(1); PYTHONPATH=$(PWD)/../src python test.py
+	@cd $(1); PYTHONPATH=$(PWD)/../src $(PYTHON) test.py
 
 endef
 

--- a/tests/advices/test.py
+++ b/tests/advices/test.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function
+
 from versuchung.experiment import Experiment
 from versuchung.files import File
 from versuchung.execute import shell
@@ -23,5 +25,5 @@ if __name__ == "__main__":
 
     if dirname:
         shutil.rmtree(dirname)
-    print "success"
+    print("success")
 

--- a/tests/basic_types/test.py
+++ b/tests/basic_types/test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from versuchung.experiment import Experiment
 from versuchung.types import String, Optional, Bool
 
@@ -23,4 +25,4 @@ if __name__ == "__main__":
     t = BasicTypesTest()
     dirname = t(["--bool", "no"] + sys.argv)
     shutil.rmtree(dirname)
-    print "success"
+    print("success")

--- a/tests/csv_read_write/test.py
+++ b/tests/csv_read_write/test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from versuchung.experiment import Experiment
 from versuchung.files import CSV_File
 
@@ -19,4 +21,4 @@ if __name__ == "__main__":
 
     if dirname:
         shutil.rmtree(dirname)
-    print "success"
+    print("success")

--- a/tests/database_basic/test.py
+++ b/tests/database_basic/test.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function
+
 from versuchung.experiment import Experiment
 from versuchung.database   import Database, TableDict, Table
 import os
@@ -44,5 +46,5 @@ if __name__ == "__main__":
 
     if r2:
         shutil.rmtree(r2)
-    print "success"
+    print("success")
 

--- a/tests/database_mergetool/test.py
+++ b/tests/database_mergetool/test.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function
+
 from versuchung.experiment import Experiment
 from versuchung.types      import Integer
 from versuchung.database   import Database, TableDict, Table, Database_SQlite_Merger
@@ -95,5 +97,5 @@ if __name__ == "__main__":
 
     os.unlink("output.db")
 
-    print "success"
+    print("success")
 

--- a/tests/directory_output/test.py
+++ b/tests/directory_output/test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from versuchung.experiment import Experiment
 from versuchung.types import String
 from versuchung.files import Directory
@@ -29,4 +31,4 @@ if __name__ == "__main__":
 
     if dirname:
         shutil.rmtree(dirname)
-    print "success"
+    print("success")

--- a/tests/event_log/test.py
+++ b/tests/event_log/test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from versuchung.experiment import Experiment
 from versuchung.events import EventLog
 
@@ -22,4 +24,4 @@ if __name__ == "__main__":
 
     if dirname:
         shutil.rmtree(dirname)
-    print "success"
+    print("success")

--- a/tests/experiment_getattr/test.py
+++ b/tests/experiment_getattr/test.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function
+
 from versuchung.experiment import Experiment
 from versuchung.files import File
 from versuchung.types import String
@@ -34,5 +36,5 @@ if __name__ == "__main__":
 
     if dirname:
         shutil.rmtree(dirname)
-    print "success"
+    print("success")
 

--- a/tests/file_output/test.py
+++ b/tests/file_output/test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from versuchung.experiment import Experiment
 from versuchung.types import String
 from versuchung.files import File, Directory
@@ -28,4 +30,4 @@ if __name__ == "__main__":
 
     if dirname:
         shutil.rmtree(dirname)
-    print "success"
+    print("success")

--- a/tests/git_archive/test.py
+++ b/tests/git_archive/test.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function
+
 from versuchung.experiment import Experiment
 from versuchung.archives import TarArchive, GitArchive
 import os
@@ -20,7 +22,7 @@ class GitArchiveTest(Experiment):
             assert path == self.i.git.value.path
             assert os.path.abspath(os.curdir) == path
 
-        print "success"
+        print("success")
 
 
 if __name__ == "__main__":

--- a/tests/gzip_file/test.py
+++ b/tests/gzip_file/test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from versuchung.experiment import Experiment
 from versuchung.archives import GzipFile
 from versuchung.files import Directory
@@ -23,4 +25,4 @@ if __name__ == "__main__":
 
     if dirname:
         shutil.rmtree(dirname)
-    print "success"
+    print("success")

--- a/tests/gzip_file/test.py
+++ b/tests/gzip_file/test.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
     experiment = SimpleExperiment()
     dirname = experiment(sys.argv)
 
-    assert len(open(experiment.gz_out.path).read()) > 0
+    assert len(open(experiment.gz_out.path, 'rb').read()) > 0
 
     if dirname:
         shutil.rmtree(dirname)

--- a/tests/list_parameter/test.py
+++ b/tests/list_parameter/test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from versuchung.experiment import Experiment
 from versuchung.types import String, List
 
@@ -27,4 +29,4 @@ if __name__ == "__main__":
 
     if dirname:
         shutil.rmtree(dirname)
-    print "success"
+    print("success")

--- a/tests/list_parameter_lambda/test.py
+++ b/tests/list_parameter_lambda/test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from versuchung.experiment import Experiment
 from versuchung.types import String, List
 from versuchung.files import File
@@ -57,4 +59,4 @@ if __name__ == "__main__":
 
     for dirname in dirs_to_del:
         shutil.rmtree(dirname)
-    print "success"
+    print("success")

--- a/tests/machine_monitor/test.py
+++ b/tests/machine_monitor/test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from versuchung.experiment import Experiment
 from versuchung.execute import shell, MachineMonitor
 
@@ -14,10 +16,10 @@ if __name__ == "__main__":
     try:
         import psutil
         if not "phymem_usage" in dir(psutil):
-            print "skipped"
+            print("skipped")
             sys.exit(0)
     except:
-        print "skipped"
+        print("skipped")
         sys.exit(0)
 
     experiment = SimpleExperiment()
@@ -25,4 +27,4 @@ if __name__ == "__main__":
 
     if dirname:
         shutil.rmtree(dirname)
-    print "success"
+    print("success")

--- a/tests/run_shell/test.py
+++ b/tests/run_shell/test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from versuchung.experiment import Experiment
 from versuchung.execute import shell, shell_failok, CommandFailed
 
@@ -27,6 +29,6 @@ if __name__ == "__main__":
     import shutil
     experiment = ShellExperiment()
     dirname = experiment(sys.argv)
-    print "success"
+    print("success")
     if dirname:
         shutil.rmtree(dirname)

--- a/tests/start_end_date/test.py
+++ b/tests/start_end_date/test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from versuchung.experiment import Experiment
 import time
 class SimpleExperiment(Experiment):
@@ -13,4 +15,4 @@ if __name__ == "__main__":
 
     if dirname:
         shutil.rmtree(dirname)
-    print "success"
+    print("success")

--- a/tests/tar_archive/test.py
+++ b/tests/tar_archive/test.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function
+
 from versuchung.experiment import Experiment
 from versuchung.archives import TarArchive
 
@@ -12,7 +14,7 @@ class TarArchiveText(Experiment):
         assert len(directory.value) == 2
         assert "ABC" in directory.value
         assert "Hallo" in directory.value
-        print "success"
+        print("success")
 
 
 if __name__ == "__main__":

--- a/tests/tex_output/test.py
+++ b/tests/tex_output/test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from versuchung.experiment import Experiment
 from versuchung.tex import *
 
@@ -40,4 +42,4 @@ if __name__ == "__main__":
     assert dref["foobar"] == "42"
 
     shutil.rmtree(dirname)
-    print "success"
+    print("success")

--- a/tests/two_experiments/test.py
+++ b/tests/two_experiments/test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from versuchung.experiment import Experiment
 from versuchung.types import String
 from versuchung.files import File
@@ -39,4 +41,4 @@ if __name__ == "__main__":
 
     if r2:
         shutil.rmtree(r2)
-    print "success"
+    print("success")


### PR DESCRIPTION
- Use 0o instead of 0 as octal literal prefix
- use print function

testsuite finishes successfully on both, python2.7 and python3.4
