### PR TITLE
shell(): pass kwargs to Popen

### DIFF
--- a/src/versuchung/archives.py
+++ b/src/versuchung/archives.py
@@ -196,7 +196,7 @@ class GitArchive(InputParameter, Type, Directory_op_with):
             Type.before_experiment_run(self, parameter_type)
 
     def __references(self, prefix_filter=None, regex_filter=None):
-        (lines, ret) = shell("git ls-remote %s 'refs/*'", self.__clone_url, stderr=PIPE)
+        (lines, ret) = shell("git ls-remote %s 'refs/*'", self.__clone_url, stderr=sys.stderr)
 
         if ret != 0 or lines == 0:
             print("\n".join(lines))
@@ -284,7 +284,7 @@ class GitArchive(InputParameter, Type, Directory_op_with):
             raise RuntimeError("GitArchive.checkout() requires branch or tag parameter")
 
         cmd = "cd '%s' && git checkout %s"
-        (lines, ret) = shell(cmd, self.value.path, self.__ref, stderr=PIPE)
+        (lines, ret) = shell(cmd, self.value.path, self.__ref, stderr=sys.stderr)
         if ret != 0:
             print("\n".join(lines))
             raise RuntimeError("GitArchive.checkout(%s) failed" % self.__ref)
@@ -298,7 +298,7 @@ class GitArchive(InputParameter, Type, Directory_op_with):
             cmd = "git ls-remote %s %s" % (self.__clone_url,
                                            self.__ref)
 
-            (lines, ret) = shell(cmd, stderr=PIPE)
+            (lines, ret) = shell(cmd, stderr=sys.stderr)
             if ret != 0 or lines == 0:
                 print("\n".join(lines))
                 sys.exit(-1)
@@ -350,7 +350,7 @@ class GitArchive(InputParameter, Type, Directory_op_with):
                 cmd = "git clone %s %s"
                 args = (self.__clone_url, self.name)
 
-            (lines, ret) = shell(cmd, *args, stderr=PIPE)
+            (lines, ret) = shell(cmd, *args, stderr=sys.stderr)
 
             if ret != 0:
                 print("\n".join(lines))
@@ -359,7 +359,7 @@ class GitArchive(InputParameter, Type, Directory_op_with):
             if not self.__shallow:
                 cmd = "cd %s && git gc && git fetch %s %s && git checkout FETCH_HEAD"
                 args = (self.name, self.__clone_url, self.__ref)
-                (lines, ret) = shell(cmd, *args, stderr=PIPE)
+                (lines, ret) = shell(cmd, *args, stderr=sys.stderr)
 
                 if ret != 0:
                     print("\n".join(lines))
@@ -368,10 +368,10 @@ class GitArchive(InputParameter, Type, Directory_op_with):
                 # Fetch all visible branches and tags
                 for branch in self.__metadata.get("branches", {}):
                     cmd = "cd %s && git fetch %s refs/heads/%s && git update-ref refs/heads/%s FETCH_HEAD"
-                    shell(cmd, self.name, self.__clone_url, branch, branch, stderr=PIPE)
+                    shell(cmd, self.name, self.__clone_url, branch, branch, stderr=sys.stderr)
                 for tag in self.__metadata.get("tags", {}):
                     cmd = "cd %s && git fetch %s refs/tags/%s && git update-ref refs/tags/%s FETCH_HEAD"
-                    shell(cmd, self.name, self.__clone_url, tag, tag, stderr=PIPE)
+                    shell(cmd, self.name, self.__clone_url, tag, tag, stderr=sys.stderr)
 
             return Directory(os.path.abspath(self.name))
 

--- a/src/versuchung/execute.py
+++ b/src/versuchung/execute.py
@@ -64,14 +64,18 @@ def quote_args(args):
     return args
 
 
-def __shell(failok, command, *args):
+def __shell(failok, command, *args, **kwargs):
     os.environ["LC_ALL"] = "C"
 
     args = quote_args(args)
     command = command % args
 
+    options = {'stdout': PIPE, 'stderr': STDOUT,
+               'shell': True, 'universal_newlines': True}
+    options.update(**kwargs)
+
     logging.debug("executing: " + command)
-    p = Popen(command, stdout=PIPE, stderr=STDOUT, shell=True, universal_newlines=True)
+    p = Popen(command, **options)
     stdout = ""
     while True:
         x = p.stdout.readline()
@@ -90,9 +94,23 @@ def __shell(failok, command, *args):
 
 
 @AdviceManager.advicable
-def shell(command, *args):
+def shell(command, *args, **kwargs):
     """
-    executes 'command' in a shell
+    | Executes ``args[0] % args[:1]`` in a shell.
+    | Keyword Arguments are passed through to the corresponding ``Popen()`` call.
+    | By default the following kwargs are passed:
+
+    +------------------------+----------------------+
+    |  Keyword               | Value                |
+    +========================+======================+
+    |  ``shell``             |  ``True``            |
+    +------------------------+----------------------+
+    |  ``stdout``            | ``subprocess.PIPE``  |
+    +------------------------+----------------------+
+    |  ``stderr``            | ``subprocess.STDOUT``|
+    +------------------------+----------------------+
+    |  ``universal_newlines``| ``True``             |
+    +------------------------+----------------------+
 
     .. note::
 
@@ -129,12 +147,12 @@ def shell(command, *args):
 
     :raises: :exc:`CommandFailed` if the returncode is != 0
     """
-    return __shell(False, command, *args)
+    return __shell(False, command, *args, **kwargs)
 
 @AdviceManager.advicable
-def shell_failok(command, *args):
+def shell_failok(command, *args, **kwargs):
     """Like :meth:`.shell`, but the throws no exception"""
-    return __shell(True, command, *args)
+    return __shell(True, command, *args, **kwargs)
 
 
 def add_sys_path(path):


### PR DESCRIPTION
This pull request passes all ``**kwargs`` that are passed to ``shell()`` commands onwards to the corresponding ``Popen(...)`` call.

Additionally this feature is then used to redirect `stderr` output when executing git commands, since capturing it might lead to incorrectly reported git metadata on some systems.