### PR TITLE
execute: don't crash if shell is stdout param

### DIFF
--- a/src/versuchung/execute.py
+++ b/src/versuchung/execute.py
@@ -77,7 +77,7 @@ def __shell(failok, command, *args, **kwargs):
     logging.debug("executing: " + command)
     p = Popen(command, **options)
     stdout = ""
-    while True:
+    while True and p.stdout is not None:
         x = p.stdout.readline()
         if not x:
             break


### PR DESCRIPTION
If the shell function was passed None or a file descriptor for stdout
redirection it would crash since stdout.readline() can't be called.
This commit adds an additional check to only print stdout lines from a
shell command if stdout is available.