### PR TITLE
Fix: Allow re-enabling shell tracking

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -10,7 +10,7 @@ $(1): py-$(1)
 
 py-$(1):
 	@echo -n "Running test: $(1)..."
-	@cd $(1); PYTHONPATH=$(PWD)/../src ${PYTHON} test.py
+	@cd $(1); PYTHONPATH=$(PWD)/.. ${PYTHON} test.py
 
 endef
 

--- a/tests/advices/test.py
+++ b/tests/advices/test.py
@@ -12,6 +12,10 @@ class SimpleExperiment(Experiment):
         shell.track(self.path)
         shell("echo 1")
         shell("cd %s && test -x ./sh", "/bin")
+        shell.track.disable()
+        shell("echo I am silent")
+        shell.track.enable()
+        shell("echo Can you hear me?")
 
 if __name__ == "__main__":
     import shutil, sys
@@ -21,7 +25,12 @@ if __name__ == "__main__":
     assert os.path.exists(dirname + "/shell_0_time")
     assert os.path.exists(dirname + "/shell_0_stdout")
     assert os.path.exists(dirname + "/shell_0_stderr")
+    assert os.path.exists(dirname + "/shell_1_stdout")
+    assert os.path.exists(dirname + "/shell_2_stdout")
+    assert not os.path.exists(dirname + "/shell_3_stdout")
 
+    with open(dirname + "/shell_2_stdout") as fd:
+        assert fd.read() == "Can you hear me?\n"
 
     if dirname:
         shutil.rmtree(dirname)

--- a/versuchung/tools.py
+++ b/versuchung/tools.py
@@ -126,6 +126,7 @@ class Advice:
                                    if x != self.around ]
         am.after[self.method] = [ x for x in am.after[self.method]
                                   if x != self.after ]
+        self.enabled = False
 
     def enable(self):
         am = self.am


### PR DESCRIPTION
`Advice` does not update its internal state in `disable()`, so that shell tacking cannot be re-enabled after disabling it. This PR fixes this bug and adds a test for disabling/enabling shell tracking.