### PR TITLE
Add new output module: LuaTable and enable passing of JSON strings

### DIFF
--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -3,7 +3,7 @@ Quick Introduction
 
 As a quick start a simple experiment with input and output parameters is show::
 
-    #!/usr/bin/python
+    #!/usr/bin/env python
 
     from versuchung.experiment import Experiment
     from versuchung.types import String
@@ -28,7 +28,7 @@ As a quick start a simple experiment with input and output parameters is show::
         experiment = SimpleExperiment()
         dirname = experiment(sys.argv)
 
-        print dirname
+        print(dirname)
 
 
 This experiment is put in a single python script file. It is a

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -26,7 +26,7 @@ As a quick start a simple experiment with input and output parameters is show::
     if __name__ == "__main__":
         import sys
         experiment = SimpleExperiment()
-        dirname = experiment(sys.argv)
+        dirname = experiment(sys.argv[1:])
 
         print(dirname)
 

--- a/doc/types/basic_types.rst
+++ b/doc/types/basic_types.rst
@@ -4,6 +4,12 @@ Basic Parameter Types
 .. autoclass:: versuchung.types.String
 	:members:
 
+.. autoclass:: versuchung.types.Integer
+	:members:
+
+.. autoclass:: versuchung.types.Bool
+	:members:
+
 .. autoclass:: versuchung.types.List
 	:members:
 

--- a/tests/advices/test.py
+++ b/tests/advices/test.py
@@ -18,9 +18,9 @@ class SimpleExperiment(Experiment):
         shell("echo Can you hear me?")
 
 if __name__ == "__main__":
-    import shutil, sys
+    import shutil
     experiment = SimpleExperiment()
-    dirname = experiment(sys.argv)
+    dirname = experiment()
 
     assert os.path.exists(dirname + "/shell_0_time")
     assert os.path.exists(dirname + "/shell_0_stdout")

--- a/tests/basic_types/test.py
+++ b/tests/basic_types/test.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     import sys
     import shutil
     t = BasicTypesTest()
-    dirname = t(["--bool", "no"] + sys.argv)
+    dirname = t(["--bool", "no"])
 
     assert BasicTypesTest(dirname).bool.value == t.bool.value
 

--- a/tests/csv_read_write/test.py
+++ b/tests/csv_read_write/test.py
@@ -11,9 +11,9 @@ class CSVExperiment(Experiment):
         self.outputs.csv.value.append([1,2,3])
 
 if __name__ == "__main__":
-    import shutil, sys
+    import shutil
     experiment = CSVExperiment()
-    dirname = experiment(sys.argv)
+    dirname = experiment([])
 
     csv = CSV_File(dirname + "/" + "csv_output")
 

--- a/tests/directory_output/test.py
+++ b/tests/directory_output/test.py
@@ -40,9 +40,9 @@ class SimpleExperiment(Experiment):
 
 
 if __name__ == "__main__":
-    import shutil, sys,os
+    import shutil, os
     experiment = SimpleExperiment()
-    dirname = experiment(sys.argv)
+    dirname = experiment([])
 
     assert os.path.isdir(experiment.o.dir2.path + "/tmpdir")
     assert os.path.exists(experiment.o.dir2.path + "/barfoo")

--- a/tests/event_log/test.py
+++ b/tests/event_log/test.py
@@ -17,10 +17,10 @@ class SimpleExperiment(Experiment):
         assert int(self.o.events.value[2][3] * 10) in [4,5,6]
 
 if __name__ == "__main__":
-    import shutil, sys
+    import shutil
 
     experiment = SimpleExperiment()
-    dirname = experiment(sys.argv)
+    dirname = experiment()
 
     if dirname:
         shutil.rmtree(dirname)

--- a/tests/experiment_getattr/test.py
+++ b/tests/experiment_getattr/test.py
@@ -30,7 +30,7 @@ class SimpleExperiment(Experiment):
 if __name__ == "__main__":
     import shutil, sys
     experiment = SimpleExperiment()
-    dirname = experiment(sys.argv)
+    dirname = experiment(sys.argv[1:])
 
     assert experiment.metadata["experiment-version"] == experiment.version
 

--- a/tests/file_output/test.py
+++ b/tests/file_output/test.py
@@ -22,9 +22,9 @@ class SimpleExperiment(Experiment):
         x = self.output_directory.new_directory("foo").new_file("lala")
 
 if __name__ == "__main__":
-    import shutil, sys
+    import shutil
     experiment = SimpleExperiment()
-    dirname = experiment(sys.argv)
+    dirname = experiment()
 
     assert os.path.exists("%s/output_directory/foo/lala" % dirname)
 

--- a/tests/git_archive/test.py
+++ b/tests/git_archive/test.py
@@ -53,10 +53,9 @@ class GitArchiveTest(Experiment):
 
 
 if __name__ == "__main__":
-    import sys
     import shutil
     t = GitArchiveTest()
-    dirname = t(sys.argv)
+    dirname = t()
 
     # Reinit of Git Archive must fail
     reinit = GitArchiveTest(dirname)

--- a/tests/gzip_file/test.py
+++ b/tests/gzip_file/test.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     import shutil, sys
 
     experiment = SimpleExperiment()
-    dirname = experiment(sys.argv)
+    dirname = experiment(sys.argv[1:])
 
     assert len(open(experiment.gz_out.original_path, 'rb').read()) > 0
 

--- a/tests/list_parameter/test.py
+++ b/tests/list_parameter/test.py
@@ -7,19 +7,24 @@ class SimpleExperiment(Experiment):
     inputs = {"strings": List(String(), default_value=[]),
               "default": List(String, default_value=[String("foo")]),
               "default2": List(String, default_value=[String("fox")]),
-              "default3": List(String, default_value=[String("a"), String("b")])
+              "default3": List(String, default_value=[String("a"), String("b")]),
+              "json": List(String),
     }
 
 
     def run(self):
         strings = [s.value for s in self.i.strings]
-        assert  strings == ["x86", "sparc"]
+        assert strings == ["x86", "sparc"]
 
         default = [s.value for s in self.i.default]
-        assert  default == ["foo"]
+        assert default == ["foo"]
 
         default2 = [s.value for s in self.i.default2]
-        assert  default2 == ["bar"]
+        assert default2 == ["bar"]
+
+        json = [s.value for s in self.i.json]
+        assert json == ['{"a": "b"}']
+
 
         assert self.metadata["strings-0"] == "x86"
         assert self.metadata["strings-1"] == "sparc"
@@ -27,7 +32,7 @@ class SimpleExperiment(Experiment):
 if __name__ == "__main__":
     import shutil
     experiment = SimpleExperiment()
-    strings = ["--strings", "x86", "--strings", "sparc", "--default2", "bar"]
+    strings = ["--strings", "x86", "--strings", "sparc", "--default2", "bar", "--json", '{"a": "b"}']
     dirname = experiment(strings)
 
     if dirname:

--- a/tests/run_shell/test.py
+++ b/tests/run_shell/test.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 from versuchung.experiment import Experiment
 from versuchung.execute import shell, shell_failok, CommandFailed
 
-import sys
 import os
 
 experiment_file = os.path.abspath(__file__)
@@ -31,7 +30,7 @@ class ShellExperiment(Experiment):
 if __name__ == "__main__":
     import shutil
     experiment = ShellExperiment()
-    dirname = experiment(sys.argv)
+    dirname = experiment()
     print("success")
     if dirname:
         shutil.rmtree(dirname)

--- a/tests/search_experiments/test.py
+++ b/tests/search_experiments/test.py
@@ -24,10 +24,10 @@ if __name__ == "__main__":
     import sys
 
     exp1 = Exp1()
-    dirname1 = exp1(sys.argv)
+    dirname1 = exp1()
 
     exp2 = Exp2()
-    dirname2 = exp2(sys.argv)
+    dirname2 = exp2()
 
     import shutil
     shutil.rmtree(dirname1)

--- a/tests/start_end_date/test.py
+++ b/tests/start_end_date/test.py
@@ -7,9 +7,9 @@ class SimpleExperiment(Experiment):
         time.sleep(0.1)
 
 if __name__ == "__main__":
-    import shutil, sys,os
+    import shutil, sys, os
     experiment = SimpleExperiment()
-    dirname = experiment(sys.argv)
+    dirname = experiment(sys.argv[1:])
 
     assert experiment.metadata["date-start"] != experiment.metadata["date-end"]
 

--- a/tests/tar_archive/test.py
+++ b/tests/tar_archive/test.py
@@ -21,5 +21,5 @@ if __name__ == "__main__":
     import sys
     import shutil
     t = TarArchiveText()
-    dirname = t(sys.argv)
+    dirname = t()
     shutil.rmtree(dirname)

--- a/tests/tex_output/test.py
+++ b/tests/tex_output/test.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
     import sys
     import shutil
     t = TexTest()
-    dirname = t(sys.argv)
+    dirname = t(sys.argv[1:])
     with open(dirname + "/macro.tex") as fd:
         content = fd.read()
         assert r'\newcommand{\foo} {bar}' in content

--- a/tests/tex_output/test.py
+++ b/tests/tex_output/test.py
@@ -5,11 +5,13 @@ from versuchung.tex import *
 
 import pandas as pd
 
+
 class TexTest(Experiment):
     outputs = {"tex": Macros("macro.tex"),
                "pgf": PgfKeyDict("pgf.tex"),
                "dref": DatarefDict("dref.tex"),
-               "pd": DatarefDict("pandas.tex") }
+               "pd": DatarefDict("pandas.tex"),
+               "lua": LuaTable("table.lua")}
 
     def run(self):
         tex = self.o.tex
@@ -73,6 +75,20 @@ class TexTest(Experiment):
         assert self.pd.get('stat/50 percent') == 4.5
         self.pd.clear()
 
+        lua = self.o.lua
+        lua["bla"] = 5
+        try:
+            class MyOwn:
+                pass
+            lua["not allowed"] = "something"
+            lua[3.2323] = "something"
+            lua["something"] = MyOwn()
+        except ValueError:
+            pass
+        lua["a"]["key"]["chain"] = "something"
+        lua[5] = "number key"
+
+
 if __name__ == "__main__":
     import sys
     import shutil
@@ -92,6 +108,13 @@ if __name__ == "__main__":
     a = dref.value
     assert len(dref) == 1
     assert dref["foobar"] == "42"
+
+    lua = LuaTable(dirname + "/table.lua")
+    a = lua.value
+    assert len(lua) == 3
+    assert lua["bla"] == 5
+    assert lua["a"]["key"]["chain"] == "something"
+    assert lua[5] == "number key"
 
     shutil.rmtree(dirname)
     print("success")

--- a/versuchung/experiment.py
+++ b/versuchung/experiment.py
@@ -14,7 +14,7 @@
 
 from __future__ import print_function
 
-from optparse import OptionParser
+from argparse import ArgumentParser
 import datetime
 import logging
 from versuchung.types import InputParameter, OutputParameter, Type
@@ -203,19 +203,24 @@ class Experiment(Type, InputParameter):
 
 
     def __setup_parser(self):
-        self.__parser = OptionParser("%prog <options>")
-        self.__parser.add_option('-d', '--base-dir', dest='base_dir', action='store',
-                                 help="Directory which is used for storing the experiment data",
-                                 default = ".")
-        self.__parser.add_option('--dummy', dest='dummy_result', action='store_true',
-                                 help="Use dummy result directory",
-                                 default=False)
-        self.__parser.add_option('-s', '--symlink', dest='do_symlink', action='store_true',
-                                 help="symlink the result dir (as newest)")
-        self.__parser.add_option('-v', '--verbose', dest='verbose', action='count', default=0,
-                                 help="increase verbosity (specify multiple times for more)")
-        self.__parser.add_option('--title', dest='title',
-                                 help="custom title of the experiment (default: Experiment class-name)")
+        self.__parser = ArgumentParser("%prog <options>")
+        self.__parser.add_argument('-d', '--base-dir',
+                                   dest='base_dir', action='store',
+                                   help="Directory which is used for storing the experiment data",
+                                   default=".")
+        self.__parser.add_argument('--dummy',
+                                   dest='dummy_result', action='store_true',
+                                   help="Use dummy result directory",
+                                   default=False)
+        self.__parser.add_argument('-s', '--symlink',
+                                   dest='do_symlink', action='store_true',
+                                   help="symlink the result dir (as newest)")
+        self.__parser.add_argument('-v', '--verbose',
+                                   dest='verbose', action='count', default=0,
+                                   help="increase verbosity (specify multiple times for more)")
+        self.__parser.add_argument('--title',
+                                   dest='title',
+                                   help="custom title of the experiment (default: Experiment class-name)")
 
         for (name, inp) in self.inputs.items():
             if type(inp) == LambdaType:
@@ -256,7 +261,7 @@ class Experiment(Type, InputParameter):
 
         # Set up the argument parsing
         self.__setup_parser()
-        (opts, args) = self.__parser.parse_args(args)
+        opts = self.__parser.parse_args(args)
         setup_logging(opts.verbose)
 
         self.__opts = opts

--- a/versuchung/tex.py
+++ b/versuchung/tex.py
@@ -1,22 +1,24 @@
 # This file is part of versuchung.
-# 
+#
 # versuchung is free software: you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software
 # Foundation, either version 3 of the License, or (at your option) any later
 # version.
-# 
+#
 # versuchung is distributed in the hope that it will be useful, but WITHOUT ANY
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License along with
 # versuchung.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import print_function
 
-from versuchung.files import File
 import re
 import os
+
+from versuchung.files import File
+
 
 class Macros(File):
     """Can be used as: **input parameter** and **output parameter**
@@ -35,7 +37,7 @@ class Macros(File):
     >>> macro = Macros("/tmp/test.tex")
     >>> macro.macro("MyNewTexMacro", 23)
     >>> print macro.value
-    \\newcommand{\MyNewTexMacro} {23}
+    \\newcommand{\\MyNewTexMacro} {23}
 
     """
     def __init__(self, filename = "data.tex"):
@@ -75,7 +77,7 @@ class PgfKeyDict(File, dict):
     >>> pgf = PgfKeyDict("/tmp/test.tex")
     >>> pgf["abcd"] = 23
     >>> pgf.flush()  # flush method of File
-    >>> print open("/tmp/test.tex").read()
+    >>> print(open("/tmp/test.tex").read())
     \\pgfkeyssetvalue{/versuchung/abcd}{23}
 
     In the TeX source you can do something like::

--- a/versuchung/types.py
+++ b/versuchung/types.py
@@ -20,7 +20,7 @@ try:
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO
-from optparse import OptionParser
+from argparse import ArgumentParser
 import copy
 import glob
 
@@ -162,7 +162,7 @@ class InputParameter:
             kw["help"]    = "(default: %s)" % default
 
         kw.update(kwargs)
-        parser.add_option('', '--%s' % option, **kw)
+        parser.add_argument(f'--{option}', **kw)
 
     def inp_parser_extract(self, opts, option):
         a = getattr(opts, self.__parser_option(option), None)
@@ -410,12 +410,12 @@ class List(InputParameter, Type, list):
             # Create Subtype and initialize its parser
             subtype = self.datatype()
             self.subobjects["%d" % len(self)] = subtype
-            subtype_parser = OptionParser()
+            subtype_parser = ArgumentParser()
             subtype.inp_setup_cmdline_parser(subtype_parser)
 
             sub_args = ["--" + subtype.name, arg]
 
-            (opts, sub_args) = subtype_parser.parse_args(sub_args)
+            opts = subtype_parser.parse_args(sub_args)
             subtype.inp_extract_cmdline_parser(opts, sub_args)
 
             self.append(subtype)

--- a/versuchung/types.py
+++ b/versuchung/types.py
@@ -392,7 +392,6 @@ class List(InputParameter, Type, list):
         Type.before_experiment_run(self,parameter_type)
 
     def inp_extract_cmdline_parser(self, opts, args):
-        import shlex
         args = self.inp_parser_extract(opts, None)
         if not args:
             return
@@ -414,20 +413,12 @@ class List(InputParameter, Type, list):
             subtype_parser = OptionParser()
             subtype.inp_setup_cmdline_parser(subtype_parser)
 
-            if not ":" in arg:
-                (opts, sub_args) = subtype_parser.parse_args(["--" + subtype.name, arg])
-            else:
-                arg = arg.replace(": ", "--" + subtype.name + " ")
-                arg = arg.replace(":", "--" + subtype.name + "-")
+            sub_args = ["--" + subtype.name, arg]
 
-                arg = shlex.split(arg)
-                (opts, sub_args) = subtype_parser.parse_args(arg)
-
-            subtype.inp_extract_cmdline_parser(opts,sub_args)
+            (opts, sub_args) = subtype_parser.parse_args(sub_args)
+            subtype.inp_extract_cmdline_parser(opts, sub_args)
 
             self.append(subtype)
-
-
 
     def inp_metadata(self):
         metadata = {self.name: []}


### PR DESCRIPTION
This pull request does multiple things at once (bad style, I know...):
- Various documentation improvements (and minimal PEP8 styling): 4f5e327, 36b5b4c, e05a998
- Fix parsing of `List(String)` if the argument is a JSON like string (and thus contains ":"): fb4732f
- Switch from (soft) deprecated OptionParser to ArgugmentParser: cfb784e
- Add a LuaTable input and output type so versuchung is usable with LuaTeX and lmtx: 69c247a

There is a little problem, though: It seems, that the LuaTable class is not embedded in the generated documentation.
I tried to run `make html` in the `doc` directory manually, which does not  include the LuaTable class, although it should include all classes of `versuchung.tex`.
This works:
```python
$ python
>>> import versuchung.tex
>>> help(versuchung.tex)
```